### PR TITLE
Bump Scala version to 2.13.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val majorChiselVersion = "6"
 val minorChiselVersion = "2"
 val chiselVersion = majorChiselVersion + "." + minorChiselVersion + ".0"
 
-scalaVersion     := "2.13.8"
+scalaVersion     := "2.13.12"
 version          := majorChiselVersion + "." + minorChiselVersion + ".4"
 organization     := "org.armadeus"
 


### PR DESCRIPTION
Hi,

I've bumped to scala version 2.13.12 in order to be compliant with your fpgamacro repository.

Cheers,
Kevin