### PR TITLE
Add wishbone error signals as options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+project/
+target/
+
+**/*.swp

--- a/src/test/scala/wbplumbing/testwbplumbing.scala
+++ b/src/test/scala/wbplumbing/testwbplumbing.scala
@@ -3,7 +3,7 @@ package wbplumbing
 import chisel3._
 import chisel3.experimental.BundleLiterals._
 import chisel3.simulator.EphemeralSimulator._
-import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 
 object general {
@@ -13,13 +13,15 @@ object general {
                   )
 }
 
-class WbInterconPTSpec extends AnyFreeSpec with Matchers {
+class WbInterconPTSpec extends AnyFlatSpec with Matchers {
 
-  "WbInterconPT should read and write wishbone value on one slave" in {
+  behavior of "WbInterconPT"
+
+  it should "read and write wishbone value on one slave" in {
     val args = general.optn
     val dataWidth = 16
-    val wbm = new WbMaster(dataWidth, 2)
-    val wbs = new WbSlave(dataWidth, 2)
+    val wbm = new WbMaster(dataWidth, 2, feature_err=true)
+    val wbs = new WbSlave(dataWidth, 2, feature_err=true)
 
     simulate(new WbInterconPT(wbm, wbs)){ dut =>
       // just a stupid testbench that verify point to point connexion
@@ -29,6 +31,7 @@ class WbInterconPTSpec extends AnyFreeSpec with Matchers {
       dut.io.wbm.stb_o.poke(true.B)
       dut.io.wbm.cyc_o.poke(true.B)
       dut.io.wbs.ack_o.poke(true.B)
+      dut.io.wbs.err_o.get.poke(true.B)
       dut.io.wbs.dat_o.poke(1.U)
       dut.clock.step(1)
       dut.io.wbm.adr_o.expect(1.U, "Wrong value read on wbm.adr_o")
@@ -37,6 +40,7 @@ class WbInterconPTSpec extends AnyFreeSpec with Matchers {
       dut.io.wbm.stb_o.expect(true.B, "Wrong value read on wbm.stb_o")
       dut.io.wbm.cyc_o.expect(true.B, "Wrong value read on wbm.cyc_o")
       dut.io.wbs.ack_o.expect(true.B, "Wrong value read on wbs.ack_o")
+      dut.io.wbs.err_o.get.expect(true.B, "Wrong value read on wbs.err_o")
       dut.io.wbs.dat_o.expect(1.U, "Wrong value read on wbs.dat_o")
       dut.io.wbm.adr_o.poke(0.U)
       dut.io.wbm.dat_o.poke(0.U)
@@ -44,6 +48,7 @@ class WbInterconPTSpec extends AnyFreeSpec with Matchers {
       dut.io.wbm.stb_o.poke(false.B)
       dut.io.wbm.cyc_o.poke(false.B)
       dut.io.wbs.ack_o.poke(false.B)
+      dut.io.wbs.err_o.get.poke(false.B)
       dut.io.wbs.dat_o.poke(0.U)
       dut.clock.step(1)
       dut.io.wbm.adr_o.expect(0.U, "Wrong value read on wbm.adr_o")
@@ -52,14 +57,17 @@ class WbInterconPTSpec extends AnyFreeSpec with Matchers {
       dut.io.wbm.stb_o.expect(false.B, "Wrong value read on wbm.stb_o")
       dut.io.wbm.cyc_o.expect(false.B, "Wrong value read on wbm.cyc_o")
       dut.io.wbs.ack_o.expect(false.B, "Wrong value read on wbs.ack_o")
+      dut.io.wbs.err_o.get.expect(false.B, "Wrong value read on wbs.err_o")
       dut.io.wbs.dat_o.expect(0.U, "Wrong value read on wbs.dat_o")
     }
   }
 }
 
-class WbInterconOneMasterSpec extends AnyFreeSpec with Matchers {
+class WbInterconOneMasterSpec extends AnyFlatSpec with Matchers {
 
-   "A WbInterconOneMaster should read and write wishbone value on two slaves" in {
+  behavior of "WbInterconOneMaster"
+
+   it should "read and write wishbone value on two slaves" in {
     val args = general.optn
     val dataWidth = 16
     val wbm =  new WbMaster(dataWidth, 7, "Spi2WbMaster")
@@ -91,6 +99,82 @@ class WbInterconOneMasterSpec extends AnyFreeSpec with Matchers {
       dut.io.wbs(0).ack_o.poke(false.B)
       dut.io.wbs(1).ack_o.poke(false.B)
 
+    }
+  }
+
+  it should "raise the err_i line of the master if read address is unmapped" in {
+    val dataWidth = 16
+    val wbm =  new WbMaster(dataWidth, 3, "Spi2WbMaster", feature_err=true)
+    val wbs1 = new WbSlave(dataWidth, 2, "Ksz1")
+
+    simulate(new WbInterconOneMaster(wbm, Seq(wbs1))) { dut =>
+      dut.io.wbm.err_i.get.expect(false.B, "bad init of err_i")
+
+      // Read on unmapped address
+      dut.io.wbm.adr_o.poke(0x4)
+      dut.io.wbm.we_o.poke(false.B)
+      dut.io.wbm.cyc_o.poke(true.B)
+      dut.io.wbm.stb_o.poke(true.B)
+      dut.clock.step(1)
+      dut.io.wbm.err_i.get.expect(true.B, "err_i not raised")
+
+      // Stop transaction
+      dut.io.wbm.cyc_o.poke(false.B)
+      dut.io.wbm.stb_o.poke(false.B)
+      dut.clock.step(1)
+      dut.io.wbm.err_i.get.expect(false.B, "err_i not resetted correctly")
+    }
+  }
+
+  it should "raise the err_i line of the master if write address is unmapped" in {
+    val dataWidth = 16
+    val wbm =  new WbMaster(dataWidth, 3, "Spi2WbMaster", feature_err=true)
+    val wbs1 = new WbSlave(dataWidth, 2, "Ksz1")
+
+    simulate(new WbInterconOneMaster(wbm, Seq(wbs1))) { dut =>
+      dut.io.wbm.err_i.get.expect(false.B, "bad init of err_i")
+
+      // Write on unmapped address
+      dut.io.wbm.adr_o.poke(0x4)
+      dut.io.wbm.we_o.poke(true.B)
+      dut.io.wbm.cyc_o.poke(true.B)
+      dut.io.wbm.stb_o.poke(true.B)
+      dut.clock.step(1)
+      dut.io.wbm.err_i.get.expect(true.B, "err_i not raised")
+
+      // Stop transaction
+      dut.io.wbm.we_o.poke(false.B)
+      dut.io.wbm.cyc_o.poke(false.B)
+      dut.io.wbm.stb_o.poke(false.B)
+      dut.clock.step(1)
+      dut.io.wbm.err_i.get.expect(false.B, "err_i not resetted correctly")
+    }
+  }
+
+  it should "pass through the err_o line of the slave to the err_i line of the master" in {
+    val dataWidth = 16
+    val wbm =  new WbMaster(dataWidth, 3, "Spi2WbMaster", feature_err=true)
+    val wbs1 = new WbSlave(dataWidth, 2, "Ksz1", feature_err=true)
+
+    simulate(new WbInterconOneMaster(wbm, Seq(wbs1))) { dut =>
+      dut.io.wbm.err_i.get.expect(false.B, "bad init of err_i")
+
+      // Write on unmapped address
+      dut.io.wbm.adr_o.poke(0x0)
+      dut.io.wbm.we_o.poke(false.B)
+      dut.io.wbm.cyc_o.poke(true.B)
+      dut.io.wbm.stb_o.poke(true.B)
+      dut.clock.step(1)
+      dut.io.wbs(0).err_o.get.poke(true.B)
+      dut.io.wbm.err_i.get.expect(true.B, "err_i not raised")
+
+      // Reset err_o
+      dut.io.wbm.we_o.poke(false.B)
+      dut.io.wbm.cyc_o.poke(false.B)
+      dut.io.wbm.stb_o.poke(false.B)
+      dut.io.wbs(0).err_o.get.poke(false.B)
+      dut.clock.step(1)
+      dut.io.wbm.err_i.get.expect(false.B, "err_i not resetted correctly")
     }
   }
 }


### PR DESCRIPTION
In the case of an unmapped address access, the ack signal will never be raised. This can be a problem if the connected module is waiting for this event. This can result in a stucked design. The ERR_I signal was implemented (as an option) to overcome such situation.